### PR TITLE
using img tags as per docs

### DIFF
--- a/src/sections/CurrentSession/CongratsModal.tsx
+++ b/src/sections/CurrentSession/CongratsModal.tsx
@@ -5,8 +5,8 @@ import { useCurrentSessionData } from "@state/sessionData/hooks"
 import { OutboundLink } from "gatsby-plugin-google-gtag"
 import React, { FunctionComponent } from "react"
 import { Modal, ModalBody } from "shards-react"
-import { StaticImage } from "gatsby-plugin-image"
 import moment from "moment"
+import dancingPepe from "../../images/dancing_pepe.gif"
 
 const ButtonsContainer = styled.div`
   margin-top: 25px;
@@ -43,8 +43,8 @@ const CongratsModal: FunctionComponent<CongratsModalProps> = ({
             Congratulations for appraising! Share it on Twitter 🎉🎉🎉
           </Label>
           {/* eslint-disable-next-line jsx-a11y/alt-text */}
-          <StaticImage
-            src="../../images/dancing_pepe.gif"
+          <img
+            src={dancingPepe}
             alt="Pepe made of unicode characters dancing"
             style={{ maxHeight: 400, maxWidth: 200, margin: 25 }}
           />

--- a/src/sections/CurrentSession/LostModal.tsx
+++ b/src/sections/CurrentSession/LostModal.tsx
@@ -1,7 +1,7 @@
 import { Label, UniversalContainer } from "@components/global.styles"
 import React, { FunctionComponent } from "react"
 import { Modal, ModalBody } from "shards-react"
-import { StaticImage } from "gatsby-plugin-image"
+import lostGIF from "../../images/lost.gif"
 
 type LostModalProps = {
   open: boolean
@@ -23,8 +23,8 @@ const LostModal: FunctionComponent<LostModalProps> = ({ open, toggle }) => (
           You unfortunately lost the pricing session! Better luck next time 😞
         </Label>
         {/* eslint-disable-next-line jsx-a11y/alt-text */}
-        <StaticImage
-          src="../../images/lost.gif"
+        <img
+          src={lostGIF}
           alt="Pepe stabbing an electrical outlet"
           style={{ maxHeight: 400, maxWidth: 200, margin: 25 }}
         />

--- a/src/sections/CurrentSession/SubscribeModal.tsx
+++ b/src/sections/CurrentSession/SubscribeModal.tsx
@@ -12,7 +12,7 @@ import {
 } from "@state/sessionData/hooks"
 import { PromiseStatus } from "@models/PromiseStatus"
 import { SessionState } from "@state/sessionData/reducer"
-import { StaticImage } from "gatsby-plugin-image"
+import dogeGIF from "../../images/happy_doge.gif"
 
 const ButtonsContainer = styled.div`
   margin-top: 25px;
@@ -83,8 +83,8 @@ const SubscribeModal: FunctionComponent<SubscribeModalProps> = ({
           {hasSubscribed ? (
             <>
               {/* eslint-disable-next-line jsx-a11y/alt-text */}
-              <StaticImage
-                src="../../images/happy_doge.gif"
+              <img
+                src={dogeGIF}
                 alt="Happy doge being scratched"
                 style={{ maxHeight: 400, maxWidth: 200, margin: 25 }}
               />


### PR DESCRIPTION
This PR switches back to img tags for GIFs as per the docs here: https://www.gatsbyjs.com/docs/how-to/images-and-media/working-with-gifs/